### PR TITLE
CI Tests

### DIFF
--- a/.github/workflows/update_build_environment.yml
+++ b/.github/workflows/update_build_environment.yml
@@ -1,0 +1,42 @@
+name: Test worksheet generation
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - environment.yml
+      - 'py_worksheet**'
+jobs:
+  test-worksheet:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        worksheet: [py_worksheet_intro, py_worksheet_reading, py_worksheet_wrangling, py_worksheet_viz, py_worksheet_version_control, py_worksheet_classification1, py_worksheet_classification2, py_worksheet_regression1, py_worksheet_regression2, py_worksheet_clustering, py_worksheet_inference1, py_worksheet_inference2]
+        envtype: [docker, conda]
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+        ref: ${{ github.head_ref }}
+    - name: Build ${{ matrix.envtype }} environment for test
+      env:
+        ENVTYPE: ${{ matrix.envtype }}
+      run: |
+        if [[ $ENVTYPE == 'docker' ]]; then
+          echo "Building docker environment for assignment generation"
+          echo "RUN pip install nbgrader" >> Dockerfile
+          docker build -t graderimage .
+        else
+          echo "Building conda environment with nbgrader for generation test"
+          conda env update --file environment.yml
+          pip install nbgrader
+        fi
+    - name: Run nbgrader assignment generation
+      run: |
+        if [[ $ENVTYPE == 'docker' ]]; then
+          echo "Running nbgrader generate assignment in a docker container"
+          docker run --rm graderimage nbgrader generate_assignment --force ${{ matrix.worksheet }}
+        else
+          echo "Running nbgrader generate assignment in the conda environment"
+          nbgrader generate_assignment --force ${{ matrix.worksheet }}
+        fi


### PR DESCRIPTION
Closes #4 

Once this works, we should make a similar change to the R worksheets repository.

NB: the only thing in this repo is the release version of the assignment. We need solutions to test them -- currently this PR uses nbgrader to generate, but that requires source vsn. Might need to add a github secret here to grab the source version and fill in solutions there to test the worksheets somehow, or perhaps grab source, generate, and compare to release version here? Maybe have an action in the instructor repo to re-release and commit here using https://github.com/cpina/github-action-push-to-another-repository? Lots of ideas...

Another one: to update the environment.yml file here automatically, have the action parse the env file here to find out which packages we installed previously, then update their version numbers and commit. It won't always work (e.g. if we add a new package) but might not be too far off, and with CI to check it should be good...